### PR TITLE
Add parseQueryString utility and tests in JavaScript

### DIFF
--- a/utils/utils.js
+++ b/utils/utils.js
@@ -1,0 +1,46 @@
+/**
+ * Parses a URL query string into an object.
+ * @param {string} query - The query string to parse.
+ * @returns {Object} - An object containing the parsed key-value pairs.
+ */
+function parseQueryString(query) {
+  if (!query) {
+    return {};
+  }
+
+  // Remove leading '?' if present
+  if (query.startsWith('?')) {
+    query = query.substring(1);
+  }
+
+  const params = {};
+  const pairs = query.split('&');
+
+  for (const pair of pairs) {
+    if (!pair) continue;
+
+    const [rawKey, rawValue] = pair.split('=');
+
+    // Replace '+' with space and decode URI components
+    const key = decodeURIComponent(rawKey.replace(/\+/g, ' '));
+    const value = rawValue !== undefined
+      ? decodeURIComponent(rawValue.replace(/\+/g, ' '))
+      : '';
+
+    if (!key) continue;
+
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      if (Array.isArray(params[key])) {
+        params[key].push(value);
+      } else {
+        params[key] = [params[key], value];
+      }
+    } else {
+      params[key] = value;
+    }
+  }
+
+  return params;
+}
+
+module.exports = { parseQueryString };

--- a/utils/utils.test.js
+++ b/utils/utils.test.js
@@ -1,0 +1,51 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { parseQueryString } = require('./utils.js');
+
+describe('parseQueryString', () => {
+  test('parses basic key-value pairs', () => {
+    const result = parseQueryString('foo=bar&baz=qux');
+    assert.deepStrictEqual(result, { foo: 'bar', baz: 'qux' });
+  });
+
+  test('handles empty query string', () => {
+    assert.deepStrictEqual(parseQueryString(''), {});
+    assert.deepStrictEqual(parseQueryString(null), {});
+    assert.deepStrictEqual(parseQueryString(undefined), {});
+  });
+
+  test('handles leading question mark', () => {
+    const result = parseQueryString('?foo=bar&baz=qux');
+    assert.deepStrictEqual(result, { foo: 'bar', baz: 'qux' });
+  });
+
+  test('decodes URI components', () => {
+    const result = parseQueryString('foo%20bar=baz%21');
+    assert.deepStrictEqual(result, { 'foo bar': 'baz!' });
+  });
+
+  test('replaces + with space', () => {
+    const result = parseQueryString('foo+bar=baz+qux');
+    assert.deepStrictEqual(result, { 'foo bar': 'baz qux' });
+  });
+
+  test('handles multiple values for the same key', () => {
+    const result = parseQueryString('foo=bar&foo=baz&foo=qux');
+    assert.deepStrictEqual(result, { foo: ['bar', 'baz', 'qux'] });
+  });
+
+  test('handles keys without values', () => {
+    const result = parseQueryString('foo=&bar');
+    assert.deepStrictEqual(result, { foo: '', bar: '' });
+  });
+
+  test('handles malformed pairs', () => {
+    const result = parseQueryString('foo=bar&&&baz=qux');
+    assert.deepStrictEqual(result, { foo: 'bar', baz: 'qux' });
+  });
+
+  test('handles only key', () => {
+      const result = parseQueryString('foo');
+      assert.deepStrictEqual(result, { foo: '' });
+  });
+});


### PR DESCRIPTION
This PR adds a JavaScript utility function `parseQueryString` to `utils/utils.js` and a corresponding test suite in `utils/utils.test.js`.

The implementation:
- Removes leading '?' if present.
- Decodes URI components.
- Replaces '+' with spaces.
- Supports multiple values for the same key by converting them to an array.

The tests use Node.js built-in `node:test` and `node:assert` modules and cover several edge cases.

---
*PR created automatically by Jules for task [3842115313059201293](https://jules.google.com/task/3842115313059201293) started by @Ruh-Al-Tarikh*